### PR TITLE
Improve error handling; always return valid application/json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /test.env
 /test.log
 /test.cookies
+/test.pid

--- a/src/httputil.rs
+++ b/src/httputil.rs
@@ -12,7 +12,6 @@ pub struct Empty {}
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Error {
-    pub code: String,
     pub message: String,
 }
 
@@ -33,87 +32,42 @@ pub struct AccountAlreadyExists;
 impl Reject for AccountAlreadyExists {}
 
 pub async fn recover_custom(r: Rejection) -> Result<impl Reply, Infallible> {
-    let (status, err) = if r.is_not_found() {
-        (
-            StatusCode::NOT_FOUND,
-            Error {
-                code: "not_found".to_string(),
-                message: "not found".to_string(),
-            },
-        )
+    let (status, message) = if r.is_not_found() {
+        (StatusCode::NOT_FOUND, "not found".to_string())
     } else if let Some(BadRequest(message)) = r.find() {
-        (
-            StatusCode::BAD_REQUEST,
-            Error {
-                code: "bad_request".to_string(),
-                message: message.to_string(),
-            },
-        )
+        (StatusCode::BAD_REQUEST, message.to_string())
     } else if let Some(Forbidden {}) = r.find() {
-        (
-            StatusCode::FORBIDDEN,
-            Error {
-                code: "forbidden".to_string(),
-                message: "forbidden".to_string(),
-            },
-        )
+        (StatusCode::FORBIDDEN, "forbidden".to_string())
     } else if let Some(InternalError {}) = r.find() {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Error {
-                code: "internal_server_error".to_string(),
-                message: "internal server error".to_string(),
-            },
+            "internal server error".to_string(),
         )
     } else if let Some(AccountAlreadyExists {}) = r.find() {
-        (
-            StatusCode::CONFLICT,
-            Error {
-                code: "conflict".to_string(),
-                message: "account already exists".to_string(),
-            },
-        )
+        (StatusCode::CONFLICT, "account already exists".to_string())
     } else if r
         .find::<warp::filters::body::BodyDeserializeError>()
         .is_some()
     {
         eprintln!("body deserialization error: {:#?}", r);
-        (
-            StatusCode::BAD_REQUEST,
-            Error {
-                code: "bad_request".to_string(),
-                message: "bad request body".to_string(),
-            },
-        )
+        (StatusCode::BAD_REQUEST, "bad request body".to_string())
     } else if r.find::<warp::reject::InvalidQuery>().is_some() {
         eprintln!("invalid query error: {:#?}", r);
-        (
-            StatusCode::BAD_REQUEST,
-            Error {
-                code: "bad_request".to_string(),
-                message: "bad request query".to_string(),
-            },
-        )
+        (StatusCode::BAD_REQUEST, "bad request query".to_string())
     } else if r.find::<warp::reject::MethodNotAllowed>().is_some() {
         eprintln!("method not allowed rejection: {:#?}", r);
         (
             StatusCode::METHOD_NOT_ALLOWED,
-            Error {
-                code: "method_not_allowed".to_string(),
-                message: "method not allowed".to_string(),
-            },
+            "method not allowed".to_string(),
         )
     } else {
         eprintln!("uhandled rejection: {:#?}", r);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Error {
-                code: "internal_server_error".to_string(),
-                message: "internal server error".to_string(),
-            },
+            "internal server error".to_string(),
         )
     };
 
-    let json = warp::reply::json(&err);
+    let json = warp::reply::json(&Error { message });
     Ok(warp::reply::with_status(json, status))
 }

--- a/src/httputil.rs
+++ b/src/httputil.rs
@@ -15,6 +15,12 @@ pub struct Error {
     pub message: String,
 }
 
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ErrorWrap {
+    pub error: Error,
+}
+
 #[derive(Debug)]
 pub struct BadRequest(pub Cow<'static, str>);
 impl Reject for BadRequest {}
@@ -68,6 +74,8 @@ pub async fn recover_custom(r: Rejection) -> Result<impl Reply, Infallible> {
         )
     };
 
-    let json = warp::reply::json(&Error { message });
+    let json = warp::reply::json(&ErrorWrap {
+        error: Error { message },
+    });
     Ok(warp::reply::with_status(json, status))
 }

--- a/src/httputil.rs
+++ b/src/httputil.rs
@@ -77,7 +77,7 @@ pub async fn recover_custom(r: Rejection) -> Result<impl Reply, Infallible> {
         .find::<warp::filters::body::BodyDeserializeError>()
         .is_some()
     {
-        eprintln!("body deserialiaztion error: {:#?}", r);
+        eprintln!("body deserialization error: {:#?}", r);
         (
             StatusCode::BAD_REQUEST,
             Error {

--- a/src/httputil.rs
+++ b/src/httputil.rs
@@ -1,9 +1,20 @@
 use std::borrow::Cow;
+use std::convert::Infallible;
 
-use http::{Response, StatusCode};
-use hyper::Body;
+use http::StatusCode;
+use serde::Serialize;
 use warp::reject::Reject;
-use warp::Rejection;
+use warp::{Rejection, Reply};
+
+#[derive(Serialize, Debug)]
+pub struct Empty {}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Error {
+    pub code: String,
+    pub message: String,
+}
 
 #[derive(Debug)]
 pub struct BadRequest(pub Cow<'static, str>);
@@ -21,28 +32,88 @@ impl Reject for InternalError {}
 pub struct AccountAlreadyExists;
 impl Reject for AccountAlreadyExists {}
 
-pub async fn recover_custom(r: Rejection) -> Result<Response<Body>, Rejection> {
-    if let Some(BadRequest(message)) = r.find() {
-        Ok(Response::builder()
-            .status(StatusCode::BAD_REQUEST)
-            .body(message.clone().into())
-            .unwrap())
+pub async fn recover_custom(r: Rejection) -> Result<impl Reply, Infallible> {
+    let (status, err) = if r.is_not_found() {
+        (
+            StatusCode::NOT_FOUND,
+            Error {
+                code: "not_found".to_string(),
+                message: "not found".to_string(),
+            },
+        )
+    } else if let Some(BadRequest(message)) = r.find() {
+        (
+            StatusCode::BAD_REQUEST,
+            Error {
+                code: "bad_request".to_string(),
+                message: message.to_string(),
+            },
+        )
     } else if let Some(Forbidden {}) = r.find() {
-        Ok(Response::builder()
-            .status(StatusCode::FORBIDDEN)
-            .body(Body::empty())
-            .unwrap())
+        (
+            StatusCode::FORBIDDEN,
+            Error {
+                code: "forbidden".to_string(),
+                message: "forbidden".to_string(),
+            },
+        )
     } else if let Some(InternalError {}) = r.find() {
-        Ok(Response::builder()
-            .status(StatusCode::INTERNAL_SERVER_ERROR)
-            .body(Body::empty())
-            .unwrap())
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Error {
+                code: "internal_server_error".to_string(),
+                message: "internal server error".to_string(),
+            },
+        )
     } else if let Some(AccountAlreadyExists {}) = r.find() {
-        Ok(Response::builder()
-            .status(StatusCode::CONFLICT)
-            .body("account already exists".into())
-            .unwrap())
+        (
+            StatusCode::CONFLICT,
+            Error {
+                code: "conflict".to_string(),
+                message: "account already exists".to_string(),
+            },
+        )
+    } else if r
+        .find::<warp::filters::body::BodyDeserializeError>()
+        .is_some()
+    {
+        eprintln!("body deserialiaztion error: {:#?}", r);
+        (
+            StatusCode::BAD_REQUEST,
+            Error {
+                code: "bad_request".to_string(),
+                message: "bad request body".to_string(),
+            },
+        )
+    } else if r.find::<warp::reject::InvalidQuery>().is_some() {
+        eprintln!("invalid query error: {:#?}", r);
+        (
+            StatusCode::BAD_REQUEST,
+            Error {
+                code: "bad_request".to_string(),
+                message: "bad request query".to_string(),
+            },
+        )
+    } else if r.find::<warp::reject::MethodNotAllowed>().is_some() {
+        eprintln!("method not allowed rejection: {:#?}", r);
+        (
+            StatusCode::METHOD_NOT_ALLOWED,
+            Error {
+                code: "method_not_allowed".to_string(),
+                message: "method not allowed".to_string(),
+            },
+        )
     } else {
-        Err(r)
-    }
+        eprintln!("uhandled rejection: {:#?}", r);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Error {
+                code: "internal_server_error".to_string(),
+                message: "internal server error".to_string(),
+            },
+        )
+    };
+
+    let json = warp::reply::json(&err);
+    Ok(warp::reply::with_status(json, status))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,7 +242,6 @@ fn json_or_error<T: Serialize, E: std::fmt::Display + std::fmt::Debug>(
             eprintln!("error: {:#?}", e);
             warp::reply::with_status(
                 warp::reply::json(&Error {
-                    code: "internal_server_error".to_string(),
                     message: format!("{:#}", e),
                 }),
                 http::StatusCode::INTERNAL_SERVER_ERROR,

--- a/test.sh
+++ b/test.sh
@@ -90,8 +90,7 @@ assertStatus() {
 }
 
 assertError() {
-  assertEquals 'error code' "$1" "$( show_output | jq -r .code )"
-  assertEquals 'error msg' "$2" "$( show_output | jq -r .message )"
+  assertEquals 'error msg' "$1" "$( show_output | jq -r .message )"
 }
 
 extractSignal() {
@@ -142,26 +141,26 @@ headers_line() {
 test404() {
   request "http://$FICAI_LISTEN/derp"
   assertStatus 'HTTP/1.1 404 Not Found'
-  assertError 'not_found' 'not found'
+  assertError 'not found'
 }
 
 test405() {
   request "http://$FICAI_LISTEN/v1/signals" -X PUT
   assertStatus 'HTTP/1.1 405 Method Not Allowed'
-  assertError 'method_not_allowed' 'method not allowed'
+  assertError 'method not allowed'
 }
 
 testUnauthorizedGet() {
   request_get
   assertStatus 'HTTP/1.1 403 Forbidden'
-  assertError 'forbidden' 'forbidden'
+  assertError 'forbidden'
 }
 
 testCreateUserInvalidJSON() {
   request "http://$FICAI_LISTEN/v1/accounts" \
     -X POST -H "Content-Type: application/json" --data-binary "{"
   assertStatus 'HTTP/1.1 400 Bad Request'
-  assertError 'bad_request' 'bad request body'
+  assertError 'bad request body'
 }
 
 testCreateUserInvalidBetaKey() {
@@ -169,7 +168,7 @@ testCreateUserInvalidBetaKey() {
     -X POST -H "Content-Type: application/json" --data-binary "{\"email\":\"$TEST_EMAIL1\",\"password\":\"pass\",\"betaKey\":\"x$FICAI_BETA_KEY\"}"
 
   assertStatus 'HTTP/1.1 400 Bad Request'
-  assertError 'bad_request' 'invalid beta key'
+  assertError 'invalid beta key'
   assertFalse "cookie must not be set" "grep -q FicAiSession test.cookies"
 }
 
@@ -186,14 +185,14 @@ testCreateUserSecondTime() {
   request "http://$FICAI_LISTEN/v1/accounts" \
     -X POST -H "Content-Type: application/json" --data-binary "{\"email\":\"$TEST_EMAIL1\",\"password\":\"pass\",\"betaKey\":\"$FICAI_BETA_KEY\"}"
   assertStatus 'HTTP/1.1 409 Conflict'
-  assertError 'conflict' 'account already exists'
+  assertError 'account already exists'
 }
 
 testGetInvalidQuery() {
   request "http://$FICAI_LISTEN/v1/signals" \
     -G --data-urlencode "urlx=$TEST_URL"
   assertStatus 'HTTP/1.1 400 Bad Request'
-  assertError 'bad_request' 'bad request query'
+  assertError 'bad request query'
 }
 
 testGetEmptySignals() {
@@ -206,7 +205,7 @@ testAddInvalidJSON() {
   request "http://$FICAI_LISTEN/v1/signals" \
     -X PATCH -H "Content-Type: application/json" --data-binary "{"
   assertStatus 'HTTP/1.1 400 Bad Request'
-  assertError 'bad_request' 'bad request body'
+  assertError 'bad request body'
 }
 
 testAdd() {
@@ -239,7 +238,7 @@ testLogInInvalidJSON() {
   request "http://$FICAI_LISTEN/v1/sessions" \
     -X POST -H "Content-Type: application/json" --data-binary "{"
   assertStatus 'HTTP/1.1 400 Bad Request'
-  assertError 'bad_request' 'bad request body'
+  assertError 'bad request body'
 }
 
 testLogIn() {
@@ -257,7 +256,7 @@ testLogInWithWrongEmail() {
     -X POST -H "Content-Type: application/json" --data-binary "{\"email\":\"$TEST_EMAIL2\",\"password\":\"pass\"}"
 
   assertStatus 'HTTP/1.1 403 Forbidden'
-  assertError 'forbidden' 'forbidden'
+  assertError 'forbidden'
 }
 
 testLogInWithWrongPassword() {
@@ -265,7 +264,7 @@ testLogInWithWrongPassword() {
     -X POST -H "Content-Type: application/json" --data-binary "{\"email\":\"$TEST_EMAIL1\",\"password\":\"wrong pass\"}"
 
   assertStatus 'HTTP/1.1 403 Forbidden'
-  assertError 'forbidden' 'forbidden'
+  assertError 'forbidden'
 }
 
 source shunit2

--- a/test.sh
+++ b/test.sh
@@ -27,6 +27,9 @@ request() {
     show_output
     show_cookies
   fi
+  # all requests should return json
+  assertEquals 'content-type: application/json' "$( grep content-type "$SHUNIT_TMPDIR/headers" | tr -d '\r\n' )"
+  assertTrue "invalid json" "cat $SHUNIT_TMPDIR/out | jq >/dev/null"
   return "$CURL_RESULT"
 }
 
@@ -82,6 +85,15 @@ show_cookies() {
   cat test.cookies
 }
 
+assertStatus() {
+  assertEquals 'http status' "$1" "$( headers_line 1 )"
+}
+
+assertError() {
+  assertEquals 'error code' "$1" "$( show_output | jq -r .code )"
+  assertEquals 'error msg' "$2" "$( show_output | jq -r .message )"
+}
+
 extractSignal() {
   <"$SHUNIT_TMPDIR/out" jq -r ".tags[]|select(.tag==\"$1\")"
 }
@@ -128,21 +140,36 @@ headers_line() {
 }
 
 test404() {
-  curl -s -D "$SHUNIT_TMPDIR/headers" -o "$SHUNIT_TMPDIR/out" "http://$FICAI_LISTEN/derp"
-  assertEquals 'HTTP/1.1 404 Not Found' "$( headers_line 1 )"
+  request "http://$FICAI_LISTEN/derp"
+  assertStatus 'HTTP/1.1 404 Not Found'
+  assertError 'not_found' 'not found'
+}
+
+test405() {
+  request "http://$FICAI_LISTEN/v1/signals" -X PUT
+  assertStatus 'HTTP/1.1 405 Method Not Allowed'
+  assertError 'method_not_allowed' 'method not allowed'
 }
 
 testUnauthorizedGet() {
   request_get
-  assertEquals 'HTTP/1.1 403 Forbidden' "$( headers_line 1 )"
-  assertTrue "[[ ! -s \"$SHUNIT_TMPDIR/out\" ]]"
+  assertStatus 'HTTP/1.1 403 Forbidden'
+  assertError 'forbidden' 'forbidden'
+}
+
+testCreateUserInvalidJSON() {
+  request "http://$FICAI_LISTEN/v1/accounts" \
+    -X POST -H "Content-Type: application/json" --data-binary "{"
+  assertStatus 'HTTP/1.1 400 Bad Request'
+  assertError 'bad_request' 'bad request body'
 }
 
 testCreateUserInvalidBetaKey() {
   request "http://$FICAI_LISTEN/v1/accounts" \
     -X POST -H "Content-Type: application/json" --data-binary "{\"email\":\"$TEST_EMAIL1\",\"password\":\"pass\",\"betaKey\":\"x$FICAI_BETA_KEY\"}"
 
-  assertEquals 'HTTP/1.1 400 Bad Request' "$( headers_line 1 )"
+  assertStatus 'HTTP/1.1 400 Bad Request'
+  assertError 'bad_request' 'invalid beta key'
   assertFalse "cookie must not be set" "grep -q FicAiSession test.cookies"
 }
 
@@ -150,27 +177,42 @@ testCreateUser() {
   request "http://$FICAI_LISTEN/v1/accounts" \
     -X POST -H "Content-Type: application/json" --data-binary "{\"email\":\"$TEST_EMAIL1\",\"password\":\"pass\",\"betaKey\":\"$FICAI_BETA_KEY\"}"
 
-  assertEquals 'HTTP/1.1 201 Created' "$( headers_line 1 )"
+  assertStatus 'HTTP/1.1 201 Created'
+  assertEquals '{}' "$( show_output )"
   assertTrue "cookie must be set" "grep -q FicAiSession test.cookies"
 }
 
 testCreateUserSecondTime() {
   request "http://$FICAI_LISTEN/v1/accounts" \
     -X POST -H "Content-Type: application/json" --data-binary "{\"email\":\"$TEST_EMAIL1\",\"password\":\"pass\",\"betaKey\":\"$FICAI_BETA_KEY\"}"
-  assertEquals 'HTTP/1.1 409 Conflict' "$( headers_line 1 )"
-  assertEquals 'account already exists' "$( show_output )"
+  assertStatus 'HTTP/1.1 409 Conflict'
+  assertError 'conflict' 'account already exists'
+}
+
+testGetInvalidQuery() {
+  request "http://$FICAI_LISTEN/v1/signals" \
+    -G --data-urlencode "urlx=$TEST_URL"
+  assertStatus 'HTTP/1.1 400 Bad Request'
+  assertError 'bad_request' 'bad request query'
 }
 
 testGetEmptySignals() {
   request_get
-  assertEquals 'HTTP/1.1 200 OK' "$( headers_line 1 )"
-  assertEquals '{"tags":[]}' "$(cat "$SHUNIT_TMPDIR/out")"
+  assertStatus 'HTTP/1.1 200 OK'
+  assertEquals '{"tags":[]}' "$( show_output )"
+}
+
+testAddInvalidJSON() {
+  request "http://$FICAI_LISTEN/v1/signals" \
+    -X PATCH -H "Content-Type: application/json" --data-binary "{"
+  assertStatus 'HTTP/1.1 400 Bad Request'
+  assertError 'bad_request' 'bad request body'
 }
 
 testAdd() {
   request_patch "$TEST_URL" +worm +taylor
   request_get
-  assertEquals 'HTTP/1.1 200 OK' "$( headers_line 1 )"
+  assertStatus 'HTTP/1.1 200 OK'
   assertSignal worm true 1 0
   assertSignal taylor true 1 0
 }
@@ -178,7 +220,7 @@ testAdd() {
 testRm() {
   request_patch "$TEST_URL" -taylor "+taylor hebert"
   request_get
-  assertEquals 'HTTP/1.1 200 OK' "$( headers_line 1 )"
+  assertStatus 'HTTP/1.1 200 OK'
   assertSignal worm true 1 0
   assertSignal taylor false 0 1
   assertSignal "taylor hebert" true 1 0
@@ -187,10 +229,17 @@ testRm() {
 testErase() {
   request_patch "$TEST_URL" %taylor
   request_get
-  assertEquals 'HTTP/1.1 200 OK' "$( headers_line 1 )"
+  assertStatus 'HTTP/1.1 200 OK'
   assertSignal worm true 1 0
   assertSignal "taylor hebert" true 1 0
   assertNoSignal taylor
+}
+
+testLogInInvalidJSON() {
+  request "http://$FICAI_LISTEN/v1/sessions" \
+    -X POST -H "Content-Type: application/json" --data-binary "{"
+  assertStatus 'HTTP/1.1 400 Bad Request'
+  assertError 'bad_request' 'bad request body'
 }
 
 testLogIn() {
@@ -198,7 +247,8 @@ testLogIn() {
   request "http://$FICAI_LISTEN/v1/sessions" \
     -X POST -H "Content-Type: application/json" --data-binary "{\"email\":\"$TEST_EMAIL1\",\"password\":\"pass\"}"
 
-  assertEquals 'HTTP/1.1 204 No Content' "$( headers_line 1 )"
+  assertStatus 'HTTP/1.1 200 OK'
+  assertEquals '{}' "$( show_output )"
   assertTrue "cookie must be set" "grep -q FicAiSession test.cookies"
 }
 
@@ -206,14 +256,16 @@ testLogInWithWrongEmail() {
   request "http://$FICAI_LISTEN/v1/sessions" \
     -X POST -H "Content-Type: application/json" --data-binary "{\"email\":\"$TEST_EMAIL2\",\"password\":\"pass\"}"
 
-  assertEquals 'HTTP/1.1 403 Forbidden' "$( headers_line 1 )"
+  assertStatus 'HTTP/1.1 403 Forbidden'
+  assertError 'forbidden' 'forbidden'
 }
 
 testLogInWithWrongPassword() {
   request "http://$FICAI_LISTEN/v1/sessions" \
     -X POST -H "Content-Type: application/json" --data-binary "{\"email\":\"$TEST_EMAIL1\",\"password\":\"wrong pass\"}"
 
-  assertEquals 'HTTP/1.1 403 Forbidden' "$( headers_line 1 )"
+  assertStatus 'HTTP/1.1 403 Forbidden'
+  assertError 'forbidden' 'forbidden'
 }
 
 source shunit2

--- a/test.sh
+++ b/test.sh
@@ -90,7 +90,7 @@ assertStatus() {
 }
 
 assertError() {
-  assertEquals 'error msg' "$1" "$( show_output | jq -r .message )"
+  assertEquals 'error msg' "$1" "$( show_output | jq -r .error.message )"
 }
 
 extractSignal() {


### PR DESCRIPTION
* always return a valid json object from all endpoints
* handle more general errors in `recover_custom`
* simplify and extend error handling
* use `sqlx::query_as`
* add some helpers in `test.sh`
