### PR TITLE
Expand account and session management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "rand_core",
  "serde",
  "sqlx",
+ "tap",
  "tokio",
  "warp",
 ]
@@ -1356,6 +1357,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ serde = { version = "1", features = ["derive"]}
 sqlx = { version = "0.5", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 warp = "0.3"
+tap = "1.0.1"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -95,6 +95,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete a session (log out).
+      operationId: delete_session
+      tags:
+        - sessions
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmptyObject"
+        '403':
+          description: Forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /signals:
     get:
       summary: Get signals for a fic.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -30,7 +30,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmptyObject"
+                $ref: "#/components/schemas/Account"
         '400':
           description: Bad request.
           content:
@@ -62,7 +62,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmptyObject"
+                $ref: "#/components/schemas/Account"
         '400':
           description: Bad request.
           content:
@@ -203,6 +203,21 @@ components:
           description: Account password.
           type: string
           minLength: 8
+    Account:
+      description: Information about an account.
+      type: object
+      required:
+        - id
+        - email
+      properties:
+        id:
+          description: The unique account id.
+          type: integer
+          format: int64
+        email:
+          description: The email account associated with this account. Must be unique.
+          type: string
+          format: email
     Signal:
       description: Signal information of a tag for a specific fic.
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -75,6 +75,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+    get:
+      summary: Get current account info.
+      operationId: get_session_account
+      tags:
+        - sessions
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Account"
+        '403':
+          description: Forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /signals:
     get:
       summary: Get signals for a fic.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use warp::{Filter as _, Reply};
 
 use crate::httputil::{recover_custom, Empty, Error};
 use crate::signal::{Signal, Signals};
-use crate::usermgmt::authenticate;
+use crate::usermgmt::{authenticate, Account};
 
 mod httputil;
 mod signal;
@@ -76,6 +76,10 @@ async fn main() -> eyre::Result<()> {
         .and(warp::body::json::<crate::usermgmt::CreateSessionQ>())
         .and(pool.clone())
         .and_then(move |q, pool| crate::usermgmt::create_session(q, pool, pepper, domain));
+    let get_session_account = warp::path!("v1" / "sessions")
+        .and(warp::get())
+        .and(authenticate.clone())
+        .and_then(crate::usermgmt::get_session_account);
 
     let get_signals = warp::path!("v1" / "signals")
         .and(warp::get())
@@ -96,6 +100,7 @@ async fn main() -> eyre::Result<()> {
     warp::serve(
         create_account
             .or(create_session)
+            .or(get_session_account)
             .or(get_signals)
             .or(patch_signals)
             .recover(recover_custom),
@@ -112,8 +117,8 @@ struct GetSignalsQ {
     url: String,
 }
 
-async fn get_signals(uid: i64, q: GetSignalsQ, pool: DB) -> eyre::Result<Signals> {
-    Signals::get(uid, q.url, &pool)
+async fn get_signals(account: Account, q: GetSignalsQ, pool: DB) -> eyre::Result<Signals> {
+    Signals::get(account.id, q.url, &pool)
         .await
         .wrap_err("failed to get signals")
 }
@@ -130,24 +135,24 @@ struct PatchSignalsQ {
     erase: Vec<String>,
 }
 
-async fn patch_signals(uid: i64, q: PatchSignalsQ, pool: DB) -> eyre::Result<Empty> {
+async fn patch_signals(account: Account, q: PatchSignalsQ, pool: DB) -> eyre::Result<Empty> {
     for tag in q.add {
         println!("add {}", &tag);
-        Signal::set(uid, &q.url, &tag, true, &pool)
+        Signal::set(account.id, &q.url, &tag, true, &pool)
             .await
             .wrap_err("failed to add signal")?
     }
 
     for tag in q.rm {
         println!("rm {}", &tag);
-        Signal::set(uid, &q.url, &tag, false, &pool)
+        Signal::set(account.id, &q.url, &tag, false, &pool)
             .await
             .wrap_err("failed to rm signal")?
     }
 
     for tag in q.erase {
         println!("erase {}", &tag);
-        Signal::erase(uid, &q.url, &tag, &pool)
+        Signal::erase(account.id, &q.url, &tag, &pool)
             .await
             .wrap_err("failed to erase signal")?
     }

--- a/test.sh
+++ b/test.sh
@@ -267,6 +267,24 @@ testGetSessionAccount() {
   assertEquals "$TEST_UID" "$( extractUid )"
 }
 
+testDeleteSession() {
+  assertTrue "cookie must be set" "grep -q FicAiSession test.cookies"
+  request "http://$FICAI_LISTEN/v1/sessions" -X DELETE
+
+  assertStatus 'HTTP/1.1 200 OK'
+  assertEquals "{}" "$( show_output )"
+  assertFalse "cookie must not be set" "grep -q FicAiSession test.cookies"
+}
+
+testDeleteSessionSecondTime() {
+  assertFalse "cookie must not be set" "grep -q FicAiSession test.cookies"
+  request "http://$FICAI_LISTEN/v1/sessions" -X DELETE
+
+  assertStatus 'HTTP/1.1 403 Forbidden'
+  assertError 'forbidden' 'forbidden'
+  assertFalse "cookie must not be set" "grep -q FicAiSession test.cookies"
+}
+
 testCreateSession() {
   rm test.cookies
   request "http://$FICAI_LISTEN/v1/sessions" \

--- a/test.sh
+++ b/test.sh
@@ -93,6 +93,10 @@ assertError() {
   assertEquals 'error msg' "$1" "$( show_output | jq -r .error.message )"
 }
 
+extractEmail() {
+  <"$SHUNIT_TMPDIR/out" jq -r ".email"
+}
+
 extractSignal() {
   <"$SHUNIT_TMPDIR/out" jq -r ".signals[]|select(.tag==\"$1\")"
 }
@@ -177,7 +181,7 @@ testCreateAccount() {
     -X POST -H "Content-Type: application/json" --data-binary "{\"email\":\"$TEST_EMAIL1\",\"password\":\"pass\",\"betaKey\":\"$FICAI_BETA_KEY\"}"
 
   assertStatus 'HTTP/1.1 201 Created'
-  assertEquals '{}' "$( show_output )"
+  assertEquals "$TEST_EMAIL1" "$( extractEmail )"
   assertTrue "cookie must be set" "grep -q FicAiSession test.cookies"
 }
 
@@ -247,7 +251,7 @@ testCreateSession() {
     -X POST -H "Content-Type: application/json" --data-binary "{\"email\":\"$TEST_EMAIL1\",\"password\":\"pass\"}"
 
   assertStatus 'HTTP/1.1 200 OK'
-  assertEquals '{}' "$( show_output )"
+  assertEquals "$TEST_EMAIL1" "$( extractEmail )"
   assertTrue "cookie must be set" "grep -q FicAiSession test.cookies"
 }
 

--- a/test.sh
+++ b/test.sh
@@ -169,7 +169,7 @@ testUnauthorizedGetSessionAccount() {
   request "http://$FICAI_LISTEN/v1/sessions"
 
   assertStatus 'HTTP/1.1 403 Forbidden'
-  assertError 'forbidden' 'forbidden'
+  assertError 'forbidden'
 }
 
 testCreateAccountInvalidJSON() {
@@ -281,7 +281,7 @@ testDeleteSessionSecondTime() {
   request "http://$FICAI_LISTEN/v1/sessions" -X DELETE
 
   assertStatus 'HTTP/1.1 403 Forbidden'
-  assertError 'forbidden' 'forbidden'
+  assertError 'forbidden'
   assertFalse "cookie must not be set" "grep -q FicAiSession test.cookies"
 }
 


### PR DESCRIPTION
* Return account info from create_account and create_session
* Add GET v1/sessions to get current account info
* Add DELETE v1/sessions to log out

Not fully happy with `AccountSession`, but not totally sure how I want to split it up and extract the sql that's still embedded directly in some of the handlers. Having an extension method on the Reply to inject the Session cookie may make sense.

Considered switching to pgcrypto's `gen_random_bytes` and erroring on the first collision on the session id as well, as that _seems_ like it's a serious issue that shouldn't be papered over if it does happen, but I have chosen not to tackle that in this PR.

Think some refactoring opportunities will become more apparent once the anonymous get_signals PR lands when the authenticate function can be broken up somewhat.